### PR TITLE
CSS tweak to make safari render spacing correctly in logo

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -164,7 +164,8 @@ section {padding: 8px 0;}
   color: var(--blue-50);
   font-size: 15vw;
   font-weight: 300;
-  letter-spacing: -0.088em;}
+  letter-spacing: -0.088em;
+  font-feature-settings: 'ss20';}
 header p { margin-top: 0; }
 .subtitle p {max-width: 37.5em;}
 p,


### PR DESCRIPTION
This adds a CSS tweak to improve the spacing of "karamalegos" on the homepage, in Safari.

![Kapture 2020-01-28 at 23 05 58](https://user-images.githubusercontent.com/45946693/73332023-d51d2600-4222-11ea-96b0-753a48574441.gif)

This patches a bug in WebKit that prevents alternate glyphs required for variation axes `rvrn` from being controlled by `letter-spacing`.  See this issue for a full description: https://github.com/arrowtype/recursive/issues/307

I have applied `ss20` (Stylistic Set 20) because I don't plan to ever actually use that in Recursive. `ss01` also works, but if you wanted to include ss01 (single-story `a`) in the Basic English subset in the future, this patch could then cause a potential unintended consequence.

Of course, this does add a line of CSS that only makes a temporary improvement in Safari browsers, so it is a bit hacky and not necessarily a best practice. BUT obviously a ton of people browse the web on Safari, and this is a particularly prominent visual aspect of the homepage – so, adding a one-line CSS hack is worth it, in my view. But, obviously, it's your call. I just stumbled upon this fix, and wanted to share that there was a way to help you dodge this Safari bug.